### PR TITLE
Improve GraphQL Yoga exception handling

### DIFF
--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -211,6 +211,7 @@ export const createGraphQLYoga = ({
 
     return { yoga, logger }
   } catch (e) {
+    logger.error(e)
     if (onException) {
       onException()
     }


### PR DESCRIPTION
Currently the GraphQL Yoga initialization code is wrapped in two separate try catch blocks. 

In the second block, exceptions are not currently logged, and if an exception is caught here, the GraphQL server fatally crashes but you get no useful logging- you just get this:
```
[0] api | /Users/willks/projects/redwood-saas-starter/node_modules/pino/lib/tools.js:59
[0] api |       if (typeof this[msgPrefixSym] === 'string' && msg !== undefined && msg !== null) {
[0] api |                      ^
[0] api | 
[0] api | TypeError: Cannot read properties of undefined (reading 'Symbol(pino.msgPrefix)')
[0] api |     at LOG (/Users/willks/projects/redwood-saas-starter/node_modules/pino/lib/tools.js:59:22)
[0] api |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[0] api | 
```

It doesn't seem to be useful to separate the initialization code into two try catches and treat them differently, as exceptions in either block are fatal, so this PR combines the two blocks. Now you get proper pino logging for exceptions wherever they occur.

Also, when I was initially trying to debug this, before looking into redwood's code, I thought about using the `onException` callback option in `GraphQLYogaOptions`, but it's not all that useful as it doesn't pass through the original exception. So this PR also changes that to pass through the original exception.